### PR TITLE
Migrated away from deprecated syscall pacakge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/billgraziano/dpapi
 
 go 1.14
 
-require github.com/pkg/errors v0.8.1
+require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/sys v0.0.0-20200828161417-c663848e9a16
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/sys v0.0.0-20200828161417-c663848e9a16 h1:54u1berWyLujz9htI1BHtZpcCEYaYNUSDFLXMNDd7To=
+golang.org/x/sys v0.0.0-20200828161417-c663848e9a16/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Switched from the deprecated `syscall` pacakge (see the note in [the godoc overview](https://pkg.go.dev/syscall?tab=doc#pkg-overview)) to the `x/sys/windows` package.